### PR TITLE
Cover API responses with types

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,26 +1,31 @@
 import axios from './axios';
+import type { AuthToken } from '@/types/auth';
+
+type LoginResponse = {
+  token: AuthToken;
+};
 
 export const logInWithCredentials = async (
   username: string,
   password: string,
-) => {
+): Promise<LoginResponse> => {
   const url = `/api/v2/auth/token/`;
   const data = {
     username,
     password,
   };
 
-  return await axios.post(url, data);
+  return (await axios.post(url, data)).data as LoginResponse;
 };
 
-export const sendLoginLink = async (email: string) => {
+export const sendLoginLink = async (email: string): Promise<void> => {
   const url = `/api/v2/auth/passwordless-token/request/${email.toLowerCase()}/`;
 
-  return await axios.get(url);
+  await axios.get(url);
 };
 
-export const logInWithLink = async (token: string) => {
+export const logInWithLink = async (token: string): Promise<LoginResponse> => {
   const url = `/api/v2/auth/passwordless-token/${token}`;
 
-  return await axios.get(url);
+  return (await axios.get(url)).data as LoginResponse;
 };

--- a/src/api/materials.ts
+++ b/src/api/materials.ts
@@ -1,7 +1,10 @@
 import axios from './axios';
+import type { MaterialContentBlocks } from '@/types/materials';
 
-export const getMaterials = async (id: string) => {
+export const getMaterialById: (
+  id: string,
+) => Promise<MaterialContentBlocks> = async (id) => {
   const url = `/api/v2/notion/materials/${id}/`;
 
-  return await axios.get(url);
+  return (await axios.get(url)).data as MaterialContentBlocks;
 };

--- a/src/api/studies.ts
+++ b/src/api/studies.ts
@@ -1,7 +1,11 @@
 import axios from './axios';
+import type { Study } from '@/types/studies';
+import type { PaginantedCollection } from '@/types/api-utility';
 
-export const getStudies = async () => {
+export const getStudies: () => Promise<
+  PaginantedCollection<Study>
+> = async () => {
   const url = `/api/v2/studies/purchased/`;
 
-  return await axios.get(url);
+  return (await axios.get(url)).data as PaginantedCollection<Study>;
 };

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -1,5 +1,5 @@
 import axios from './axios';
-import type { Gender } from '@/stores/user';
+import type { EditableUserProperties } from '@/types/users';
 
 export const getUser = async () => {
   const url = '/api/v2/users/me/';
@@ -7,17 +7,7 @@ export const getUser = async () => {
   return await axios.get(url);
 };
 
-export interface EditableUserData {
-  first_name?: string;
-  last_name?: string;
-  first_name_en?: string;
-  last_name_en?: string;
-  gender?: Gender;
-  linkedin_username?: string;
-  github_username?: string;
-}
-
-export const setUser = async (data: EditableUserData) => {
+export const setUser = async (data: EditableUserProperties) => {
   const url = '/api/v2/users/me/';
 
   return await axios.patch(url, data);

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -1,14 +1,15 @@
 import axios from './axios';
-import type { EditableUserProperties } from '@/types/users';
+import type { User, EditableUserProperties } from '@/types/users';
 
-export const getUser = async () => {
+export const getUser: () => Promise<User> = async () => {
   const url = '/api/v2/users/me/';
+  const response = await axios.get(url);
 
-  return await axios.get(url);
+  return response.data as User;
 };
 
-export const setUser = async (data: EditableUserProperties) => {
+export const setUser = async (data: EditableUserProperties): Promise<User> => {
   const url = '/api/v2/users/me/';
 
-  return await axios.patch(url, data);
+  return (await axios.patch(url, data)).data as User;
 };

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,9 +1,14 @@
 import { defineStore } from 'pinia';
+import type { AuthToken } from '@/types/auth';
 import { logInWithCredentials, sendLoginLink, logInWithLink } from '@/api/auth';
 import useToasts from './toasts';
 
+type AuthStoreState = {
+  token: AuthToken | undefined;
+};
+
 const useAuth = defineStore('auth', {
-  state: () => {
+  state: (): AuthStoreState => {
     return {
       token: undefined,
     };
@@ -11,8 +16,8 @@ const useAuth = defineStore('auth', {
   actions: {
     async loginWithCredentials(username: string, password: string) {
       try {
-        const response = await logInWithCredentials(username, password);
-        this.token = response.data.token;
+        const loginResult = await logInWithCredentials(username, password);
+        this.token = loginResult.token;
       } catch (error: any) {}
     },
     async loginWithEmail(email: string) {
@@ -27,8 +32,8 @@ const useAuth = defineStore('auth', {
     },
     async exchangeTokens(passwordlessToken: string) {
       try {
-        const response = await logInWithLink(passwordlessToken);
-        this.token = response.data.token;
+        const loginResult = await logInWithLink(passwordlessToken);
+        this.token = loginResult.token;
       } catch (error: any) {}
     },
     resetAuth() {

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -24,12 +24,12 @@ const useUser = defineStore('user', {
     async getUserStudies() {
       try {
         const response = await getStudies();
-        this.studies = response.data.results;
+        this.studies = response.results;
       } catch (err) {}
     },
     async getUserData() {
       try {
-        const response = await getUser();
+        const user = await getUser();
 
         const {
           id,
@@ -42,7 +42,7 @@ const useUser = defineStore('user', {
           gender,
           linkedin_username,
           github_username,
-        } = response.data;
+        } = user;
 
         this.id = id;
         this.uuid = uuid;
@@ -96,7 +96,7 @@ const useUser = defineStore('user', {
           data.github_username = github_username;
         }
 
-        await setUser(data);
+        console.log(await setUser(data));
         const toasts = useToasts();
         toasts.addMessage('Данные сохранены!', 'success');
       } catch (error: any) {}

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -96,6 +96,7 @@ const useUser = defineStore('user', {
           data.github_username = github_username;
         }
 
+        await setUser(data);
         const toasts = useToasts();
         toasts.addMessage('Данные сохранены!', 'success');
       } catch (error: any) {}

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -1,39 +1,11 @@
 import { defineStore } from 'pinia';
 import { setUser, getUser } from '@/api/users';
-import type { EditableUserData } from '@/api/users';
+import type { User, EditableUserProperties } from '@/types/users';
 import { getStudies } from '@/api/studies';
 import useToasts from '@/stores/toasts';
 
-export type Gender = 'female' | 'male' | undefined;
-
-interface Study {
-  id: number;
-  slug: string;
-  name: string;
-  home_page_slug: string;
-}
-
-export interface User {
-  id: string;
-  uuid: string;
-  username: string;
-}
-
-export interface UserData {
-  first_name: string;
-  last_name: string;
-  first_name_en: string;
-  last_name_en: string;
-  gender: Gender;
-  linkedin_username: string;
-  github_username: string;
-  studies: Study[];
-}
-
-interface State extends User, UserData {}
-
 const useUser = defineStore('user', {
-  state: (): State => {
+  state: (): User => {
     return {
       id: '',
       uuid: '',
@@ -92,9 +64,9 @@ const useUser = defineStore('user', {
       gender,
       linkedin_username,
       github_username,
-    }: EditableUserData) {
+    }: EditableUserProperties) {
       try {
-        const data: EditableUserData = {};
+        const data: EditableUserProperties = {};
 
         if (this.first_name !== first_name) {
           data.first_name = first_name;

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -96,7 +96,6 @@ const useUser = defineStore('user', {
           data.github_username = github_username;
         }
 
-        console.log(await setUser(data));
         const toasts = useToasts();
         toasts.addMessage('Данные сохранены!', 'success');
       } catch (error: any) {}

--- a/src/types/api-utility.ts
+++ b/src/types/api-utility.ts
@@ -1,0 +1,8 @@
+type PaginationUrl = string;
+
+export type PaginantedCollection<T> = {
+  count: number;
+  next: PaginationUrl;
+  previous: PaginationUrl;
+  results: T[];
+};

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,1 @@
+export type AuthToken = string;

--- a/src/types/materials.ts
+++ b/src/types/materials.ts
@@ -1,0 +1,9 @@
+export type MaterialContentBlockId = string;
+export type MaterialContentBlock = {
+  value: {
+    id: MaterialContentBlockId;
+  };
+};
+export type MaterialContentBlocks = {
+  [k: MaterialContentBlockId]: MaterialContentBlock;
+};

--- a/src/types/studies.ts
+++ b/src/types/studies.ts
@@ -1,0 +1,6 @@
+export type Study = {
+  id: number;
+  slug: string;
+  name: string;
+  home_page_slug: string;
+};

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -1,0 +1,29 @@
+import type { Study } from '@/types/studies';
+
+export type Gender = 'female' | 'male' | undefined;
+
+export interface User {
+  id: string;
+  uuid: string;
+  username: string;
+  first_name: string;
+  last_name: string;
+  first_name_en: string;
+  last_name_en: string;
+  gender: Gender;
+  linkedin_username: string;
+  github_username: string;
+  studies: Study[];
+}
+
+type EditableUserPropertyNames =
+  | 'first_name'
+  | 'last_name'
+  | 'first_name_en'
+  | 'last_name_en'
+  | 'gender'
+  | 'linkedin_username'
+  | 'github_username';
+export type EditableUserProperties = Partial<
+  Pick<User, EditableUserPropertyNames>
+>;

--- a/src/views/NotionView.vue
+++ b/src/views/NotionView.vue
@@ -3,16 +3,18 @@
   import { NotionRenderer } from 'vue3-notion';
   import { useRoute } from 'vue-router';
   import { onMounted, ref } from 'vue';
+  import type { MaterialContentBlocks } from '@/types/materials';
+
   import Preloader from '../components/Preloader.vue';
-  import { getMaterials } from '@/api/materials';
+  import { getMaterialById } from '@/api/materials';
 
   const route = useRoute();
-  const blocks = ref('');
+  const blocks = ref<MaterialContentBlocks | undefined>(undefined);
 
   onMounted(async () => {
-    const response = await getMaterials(String(route.params.id));
+    const newBlocks = await getMaterialById(String(route.params.id));
 
-    blocks.value = response.data;
+    blocks.value = newBlocks;
   });
 
   const mapPageUrl = (id: string) => `/materials/${id}`;

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -4,7 +4,7 @@
   import { onMounted, ref } from 'vue';
   import type { Ref } from 'vue';
   import useUser from '@/stores/user';
-  import type { Gender } from '@/stores/user';
+  import type { Gender } from '@/types/users';
 
   const user = useUser();
 


### PR DESCRIPTION
Покрыл ответы от API типами. До этого любые данные из API были с типом any. 

 Чтобы было удобнее работать с типами, API-модули теперь сами ответственны за вытаскивание data из response-а от axios. До этого этим занимались consumer-ы API-модулей.
Заодно вынес общие типы в папку `@/types`.