### PR TITLE
Add types for component emits

### DIFF
--- a/src/components/TextInput.vue
+++ b/src/components/TextInput.vue
@@ -6,7 +6,9 @@
     modelValue: { type: String, default: '' },
   });
 
-  const emit = defineEmits(['update:modelValue']);
+  const emit = defineEmits<{ 
+    (e: 'update:modelValue', value: string): void 
+  }>()
 
   const handleInput = (e: Event) => {
     const value = (e.target as HTMLInputElement).value;

--- a/src/components/Toast.vue
+++ b/src/components/Toast.vue
@@ -8,7 +8,9 @@
     type: { type: String, required: false },
   });
 
-  const emit = defineEmits(['delete']);
+  const emit = defineEmits<{ 
+    (e: 'delete', id: string): void 
+  }>()
   let timeout: ReturnType<typeof setTimeout>;
 
   onMounted(() => {


### PR DESCRIPTION
Добавил типы в определения emit-ов компонентов.
@brachkow предлагаю типизировать emit-ы сразу — это несложно, и добавляет еще один слой защиты от случайных поломок публичного API компонентов. 