### PR TITLE
Работает на локалхосте без ipv6

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     host: true,
     port: 3000,
     proxy: {
-      '/api': 'http://localhost:8000',
+      '/api': 'http://127.0.0.1:8000',
     },
   },
   plugins: [vue()],


### PR DESCRIPTION
Если запускать бекенд на mac os (где localhost резолвится в `::1`) без докера, то ничего не работает — джанга по дефолту слушает только ipv4.

Этот фикс должен починить работу с бекендом для всех тачек.