### PR TITLE
Update docker-compose.yml with NOTION_CACHE_ONLY

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - AWS_ACCESS_KEY_ID=root
       - AWS_SECRET_ACCESS_KEY=ibcxJ8Du
       - AWS_STORAGE_BUCKET_NAME=dev
+      - NOTION_CACHE_ONLY=On
 
     ports:
       - 8000:8000


### PR DESCRIPTION
Always use existing cache for Notion on dev machine

[Basecamp Issue](https://3.basecamp.com/5104612/buckets/29069198/todos/6254276952#__recording_6346974813)