### PR TITLE
Force https on crossorigin images to avoid automatic protocol upgrade

### DIFF
--- a/apps/frontend/src/composables/useCrossOriginImages.ts
+++ b/apps/frontend/src/composables/useCrossOriginImages.ts
@@ -6,6 +6,8 @@ import { onMounted } from 'vue';
  * See https://whatwebcando.today/articles/opaque-responses-service-worker/
  */
 export function useCrossOriginImages() {
+  if (import.meta.env.DEV) return;
+
   onMounted(() => {
     useMutationObserver(
       document.querySelector('body'),

--- a/apps/frontend/src/composables/useCrossOriginImages.ts
+++ b/apps/frontend/src/composables/useCrossOriginImages.ts
@@ -20,6 +20,8 @@ export function useCrossOriginImages() {
             const images = node.querySelectorAll('img');
             for (const image of images) {
               image.crossOrigin = 'anonymous';
+              // Assume all images come from our CDN which supports HTTPS and CORS.
+              image.src = image.src.replace('http:', 'https:');
             }
           }
         }


### PR DESCRIPTION
https://3.basecamp.com/5104612/buckets/29069198/todos/8906556753#__recording_8908422164

Course cover images are served over `http://`. After I [enabled CORS on images](https://github.com/tough-dev-school/lms-frontend-v2/pull/407), Chrome and newer Safari versions have been able to upgrade http -> https automatically:
<img width="1093" height="65" alt="image" src="https://github.com/user-attachments/assets/e6ced1d8-78de-45a4-87ce-48f0497201cd" />.

Forcing `https://` gets rid of the warning in Chrome and fixes the issue on older Safari.
